### PR TITLE
Require approval to get building access

### DIFF
--- a/keycloak/keycloak.go
+++ b/keycloak/keycloak.go
@@ -143,6 +143,9 @@ func newAccessUser(kcuser *gocloak.User) *AccessUser {
 	if fobID == 0 {
 		return nil
 	}
+	if firstElOrZeroVal(attr["buildingAccessApprover"]) == "" {
+		return nil // no access for accounts that haven't explicitly been granted building access
+	}
 
 	return &AccessUser{
 		UUID:         *kcuser.ID,


### PR DESCRIPTION
A keycloak admin must now approve an account before it is granted building access. This allows us to meet them, make sure they're a real person, etc. before enabling their fob.

Users are still able to immediately set a fob when creating an account, it just won't be activated yet.